### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,5 +1,10 @@
 name: Docker
 
+permissions:
+  contents: read
+  packages: write
+  actions: read
+
 on:
   push:
     # Publish `djo` as Docker `latest` image.


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/LedenAdministratie/security/code-scanning/12](https://github.com/djoamersfoort/LedenAdministratie/security/code-scanning/12)

To fix the issue, add a `permissions` block at the root of the workflow file to define the least privileges required for the workflow. Based on the tasks performed in the workflow, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to GitHub Packages.
- `actions: read` for using actions like `docker/login-action` and `docker/build-push-action`.

The `permissions` block should be added at the top level of the workflow file, ensuring it applies to all jobs unless overridden by job-specific permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
