### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -1,4 +1,6 @@
 name: Run PR Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/djoamersfoort/LedenAdministratie/security/code-scanning/11](https://github.com/djoamersfoort/LedenAdministratie/security/code-scanning/11)

To fix the issue, we will add a `permissions` block at the workflow level (root level) to explicitly define the least privileges required. Since the workflow only checks out the repository and runs linting tools, it only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` cannot perform any write operations.

The `permissions` block will be added directly below the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
